### PR TITLE
Add header tests, set headers correctly

### DIFF
--- a/json.go
+++ b/json.go
@@ -7,6 +7,7 @@ import (
 
 // WriteError writes a string as JSON encoded error
 func WriteError(w http.ResponseWriter, code int, err string) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(code)
 
 	WriteJSON(w, map[string]string{
@@ -29,6 +30,7 @@ func WriteJSON(w http.ResponseWriter, v interface{}) error {
 // WriteJSONWithStatus writes the given statuscode into the header and the
 // given interface as JSON  or returns an error
 func WriteJSONWithStatus(w http.ResponseWriter, code int, v interface{}) error {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(code)
 
 	return WriteJSON(w, v)

--- a/json_test.go
+++ b/json_test.go
@@ -21,12 +21,19 @@ func TestWriteError(t *testing.T) {
 	w := httptest.NewRecorder()
 	WriteError(w, code, err)
 
-	// Test code
+	// Test Code
 	if w.Code != code {
 		t.Errorf("WriteError should set Code to %i, but did set it to %i", code, w.Code)
 	}
 
-	// Test body
+	// Test Header
+	expectedContentTypeHeader := "application/json; charset=utf-8"
+	contentTypeHeader := w.Header().Get("Content-Type")
+	if contentTypeHeader != expectedContentTypeHeader {
+		t.Errorf("WriteError should set Content-Type header to %s, but did set it to %s", expectedContentTypeHeader, contentTypeHeader)
+	}
+
+	// Test Body
 	if w.Body == nil {
 		t.Errorf("WriteError should set Body to %s, but didn't", json)
 	} else if string(w.Body.Bytes()) == string(buf.Bytes()) {
@@ -49,13 +56,21 @@ func TestWriteJSON(t *testing.T) {
 	w := httptest.NewRecorder()
 	WriteJSON(w, in)
 
+	// Test Body
 	if w.Body == nil {
 		t.Errorf("WriteJSON should set the Body to %s, but didn't", json)
 	} else if string(w.Body.Bytes()) == string(buf.Bytes()) {
 		t.Errorf("WriteJSON set the Body to %v, but should set it to %v", buf, w.Body)
 	}
 
-	// Test error
+	// Test Header
+	expectedContentTypeHeader := "application/json; charset=utf-8"
+	contentTypeHeader := w.Header().Get("Content-Type")
+	if contentTypeHeader != expectedContentTypeHeader {
+		t.Errorf("WriteJSON should set Content-Type header to %s, but did set it to %s", expectedContentTypeHeader, contentTypeHeader)
+	}
+
+	// Test Error
 	w = httptest.NewRecorder()
 	if err := WriteJSON(w, WriteJSON); err == nil {
 		t.Errorf("WriteJSON should return an error, but didn't")
@@ -79,12 +94,19 @@ func TestWriteJSONWithStatus(t *testing.T) {
 	w := httptest.NewRecorder()
 	WriteJSONWithStatus(w, code, in)
 
-	// test code
+	// Test Code
 	if w.Code != code {
 		t.Errorf("WriteJSONWithStatus should set Code to %i, but did set it to %i", code, w.Code)
 	}
 
-	// test body
+	// Test Header
+	expectedContentTypeHeader := "application/json; charset=utf-8"
+	contentTypeHeader := w.Header().Get("Content-Type")
+	if contentTypeHeader != expectedContentTypeHeader {
+		t.Errorf("WriteJSONWithStatus should set Content-Type header to %s, but did set it to %s", expectedContentTypeHeader, contentTypeHeader)
+	}
+
+	// Test Body
 	if w.Body == nil {
 		t.Errorf("WriteJSONWithStatus should set the Body to %s, but didn't", json)
 	} else if string(w.Body.Bytes()) == string(buf.Bytes()) {


### PR DESCRIPTION
- Adds tests for the `Content-Type`-header
- Fixes some comments
- Sets headers in every `JSON`-related function correctly, completely fixing #4. :bug:

Sorry I didn't really get what you meant with your first comment in #4, but I fixed it now :grin: 