### PR TITLE
All routes showing in IndexHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,13 +85,15 @@ func main() {
 The above example would return the following response on `/`:
 ```json
 {
-  "hello_url": "/hello/:name",
-  "user_logout_url": "/user/logout"
+  "GET": {
+    "hello_url": "/hello/:name"
+    "user_logout_url": "/user/logout"
+  },
+  "POST": {
+    "user_login_url": "/login"
+  }
 }
 ```
-
-**Note:** Indices are only supported for `GET` requests. Open an issue, if you
-want them on other methods, too
 
 ### Middleware
 You can easily include any middleware you like. A great guide to middleware

--- a/index.go
+++ b/index.go
@@ -10,7 +10,7 @@ func (r *Router) IndexHandler(w http.ResponseWriter, _ *http.Request, _ Params) 
 	WriteJSON(w, r.Index())
 }
 
-// Index returns a string map with the titles and urls of all GET routes
+// Index returns a string map with the titles and urls of all routes
 func (r *Router) Index() map[string]string {
 	index := r.index
 

--- a/index.go
+++ b/index.go
@@ -2,7 +2,7 @@ package goat
 
 import (
 	"net/http"
-	"sort"
+	"reflect"
 )
 
 // IndexHandler writes the index of all GET methods to the ResponseWriter
@@ -10,29 +10,26 @@ func (r *Router) IndexHandler(w http.ResponseWriter, _ *http.Request, _ Params) 
 	WriteJSON(w, r.Index())
 }
 
-// Index returns a string map with the titles and urls of all routes
-func (r *Router) Index() map[string]string {
-	index := r.index
+// Index returns a string map with the titles and urls of all routes, grouped by method
+func (r *Router) Index() map[string]map[string]string {
+	index := r.methodIndex
 
 	// Recursion
 	for _, sr := range r.children {
 		si := sr.Index()
 
-		for k, v := range si {
-			index[k] = v
+		for method, routes := range si {
+			for title, url := range routes {
+				if reflect.DeepEqual(index, reflect.Zero(reflect.TypeOf(index)).Interface()) {
+					index = make(map[string]map[string]string)
+				}
+				if reflect.DeepEqual(index[method], reflect.Zero(reflect.TypeOf(index[method])).Interface()) {
+					index[method] = make(map[string]string)
+				}
+				index[method][title] = url
+			}
 		}
 	}
 
-	// Sort
-	sorted := make(map[string]string)
-	var keys []string
-	for k := range index {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	for _, k := range keys {
-		sorted[k] = index[k]
-	}
-
-	return sorted
+	return index
 }

--- a/index_test.go
+++ b/index_test.go
@@ -17,12 +17,16 @@ func TestIndex(t *testing.T) {
 	sr.Get("/", "sub_url", emptyHandler)
 
 	out := r.Index()
-	expected := map[string]string{
-		"foo_url":     "/foo",
-		"bar_url":     "/bar",
-		"foo_bar_url": "/foo/bar",
-		"sub_url":     "/sub/",
-	}
+	expected := map[string]map[string]string{
+		"GET": {
+			"bar_url": "/bar",
+			"foo_bar_url": "/foo/bar",
+			"sub_url": "/sub/",
+			},
+		"POST": {
+			"foo_url": "/foo",
+			},
+		}
 	if !reflect.DeepEqual(out, expected) {
 		t.Errorf("Index should return %v, but did return %v", expected, out)
 	}
@@ -39,9 +43,13 @@ func TestIndexHandler(t *testing.T) {
 	r.IndexHandler(w, nil, p)
 
 	expected := `{
-  "bar_url": "/bar",
-  "foo_bar_url": "/foo/bar",
-  "foo_url": "/foo"
+  "GET": {
+    "bar_url": "/bar",
+    "foo_bar_url": "/foo/bar"
+  },
+  "POST": {
+    "foo_url": "/foo"
+  }
 }`
 	body := string(w.Body.Bytes())
 

--- a/index_test.go
+++ b/index_test.go
@@ -18,6 +18,7 @@ func TestIndex(t *testing.T) {
 
 	out := r.Index()
 	expected := map[string]string{
+		"foo_url":     "/foo",
 		"bar_url":     "/bar",
 		"foo_bar_url": "/foo/bar",
 		"sub_url":     "/sub/",
@@ -39,7 +40,8 @@ func TestIndexHandler(t *testing.T) {
 
 	expected := `{
   "bar_url": "/bar",
-  "foo_bar_url": "/foo/bar"
+  "foo_bar_url": "/foo/bar",
+  "foo_url": "/foo"
 }`
 	body := string(w.Body.Bytes())
 

--- a/router.go
+++ b/router.go
@@ -49,7 +49,7 @@ func (r *Router) addRoute(m, p, t string, fn Handle) {
 	path := r.subPath(p)
 
 	// Add to index
-	if len(t) > 0 && m == "GET" {
+	if len(t) > 0 {
 		// TODO: Display total path including host
 		r.index[t] = path
 	}

--- a/router.go
+++ b/router.go
@@ -2,6 +2,7 @@ package goat
 
 import (
 	"net/http"
+	"reflect"
 
 	"github.com/julienschmidt/httprouter"
 )
@@ -17,6 +18,9 @@ type Router struct {
 
 	// The index, maps titles to urls
 	index map[string]string
+
+	// The method index, maps methods to titles to urls
+	methodIndex map[string]map[string]string
 
 	// The router
 	router *httprouter.Router
@@ -52,6 +56,13 @@ func (r *Router) addRoute(m, p, t string, fn Handle) {
 	if len(t) > 0 {
 		// TODO: Display total path including host
 		r.index[t] = path
+		if reflect.DeepEqual(r.methodIndex, reflect.Zero(reflect.TypeOf(r.methodIndex)).Interface()) {
+			r.methodIndex = make(map[string]map[string]string)
+		}
+		if reflect.DeepEqual(r.methodIndex[m], reflect.Zero(reflect.TypeOf(r.methodIndex[m])).Interface()) {
+			r.methodIndex[m] = make(map[string]string)
+		}
+		r.methodIndex[m][t] = path
 	}
 
 	// Wrapper function to bypass the parameter problem

--- a/router_test.go
+++ b/router_test.go
@@ -35,6 +35,15 @@ func TestAddRoute(t *testing.T) {
 	if !reflect.DeepEqual(r.index, expected) {
 		t.Errorf("addRoute should modify Router.index to %v, but did modify it to %v", expected, r.index)
 	}
+
+	r.addRoute("POST", "/foo/baz", "foo_baz_url", emptyHandler)
+	expected = map[string]string{
+		"foo_bar_url": "/foo/bar",
+		"foo_baz_url": "/foo/baz",
+	}
+	if !reflect.DeepEqual(r.index, expected) {
+		t.Errorf("addRoute should modify Router.index to %v, but did modify it to %v", expected, r.index)
+	}
 }
 
 func TestSubrouter(t *testing.T) {


### PR DESCRIPTION
As per #9, I thought I could help as I liked that feature as well.
- [X] Make all routes show up (not only GETs)
- [X] Update tests

What about displaying the method of each route? What could your suggested strategy be?
This structure came up on top of my mind:

``` json
{
  "hello_url": {
    "method": "GET",
    "path": "/hello/:name"
  },
  "user_logout_url": {
    "method": "POST",
    "path": "/user/logout"
  }
}
```

Do I have the :green_apple: light to go on?
